### PR TITLE
Safer class creation with Hera.

### DIFF
--- a/Hera-UI/HeraFeatureSelector.class.st
+++ b/Hera-UI/HeraFeatureSelector.class.st
@@ -28,23 +28,40 @@ HeraFeatureSelector >> acceptanceTestClassItems [
 HeraFeatureSelector >> addAcceptanceTestClass [
 
 	| className packageName acceptanceTestClass |
-	self flag: 'This UI interaction can be improved a lot by using a dedicated dialog'.
-	className := [ self
-		request: 'Please enter the name of the class.'
-		initialAnswer: 'MyAcceptanceTest'
-		title: 'New Acceptance Test Class' ]
-		on: SpCancelledInteractionError do: [ ^ self ].
-	packageName := [ self
-		request: 'Please enter the name of the package of the class.'
-		initialAnswer: 'MyPackage'
-		title: 'New Acceptance Test Class' ]
-		on: SpCancelledInteractionError do: [ ^ self ].
-	self flag: 'TODO: check validity of the class name and the package name'.
+	self flag:
+		'This UI interaction can be improved a lot by using a dedicated dialog'.
+	className := [
+		             self
+			             request: 'Please enter the name of the class.'
+			             initialAnswer: 'MyAcceptanceTest'
+			             title: 'New Acceptance Test Class' ]
+		             on: SpCancelledInteractionError
+		             do: [ ^ self ].
+	className isValidGlobalName ifFalse: [
+			self inform: 'Invalid class name.'.
+			^ self ].
+	(Smalltalk environment classNamed: className) ifNotNil: [ :aClass |
+			(self application newConfirm
+				 title: 'Override class';
+				 label:
+					 'You are about to override an existing class. Are you sure you want to do that ?';
+				 openModal) ifFalse: [ ^ self ] ].
+
+	packageName := [
+		               self
+			               request:
+			               'Please enter the name of the package of the class.'
+			               initialAnswer: 'MyPackage'
+			               title: 'New Acceptance Test Class' ]
+		               on: SpCancelledInteractionError
+		               do: [ ^ self ].
+	self flag: 'TODO: check validity of the package name'.
+
 	acceptanceTestClass := Smalltalk classInstaller make: [ :classBuilder |
-		classBuilder
-			name: className;
-			superclass: HeraAcceptanceTest;
-			package: packageName ].
+			                       classBuilder
+				                       name: className;
+				                       superclass: HeraAcceptanceTest;
+				                       package: packageName ].
 	self scope addClass: acceptanceTestClass.
 	self updateClassesAndFeaturesAfterAddingClass: acceptanceTestClass
 ]

--- a/Hera-UI/HeraFeatureSelector.class.st
+++ b/Hera-UI/HeraFeatureSelector.class.st
@@ -60,7 +60,7 @@ HeraFeatureSelector >> addAcceptanceTestClass [
 	acceptanceTestClass := Smalltalk classInstaller make: [ :classBuilder |
 			                       classBuilder
 				                       name: className;
-				                       superclass: HeraAcceptanceTest;
+				                       superclass: HeraSpecAcceptanceTest;
 				                       package: packageName ].
 	self scope addClass: acceptanceTestClass.
 	self updateClassesAndFeaturesAfterAddingClass: acceptanceTestClass


### PR DESCRIPTION
Currently Hera do not check if the class is already used before overriding it.
I added a modal dialog that ask for the confirmation if it is the case.

Safer class creation with Hera:
* Check if the class name is "valid"
* Check if the classname is already used and ask for confirmation


![image](https://github.com/user-attachments/assets/ec0b7b9a-d512-46dd-b2a3-380759822a15)
